### PR TITLE
Better norsk in yr.rb

### DIFF
--- a/lib/cinch/plugins/yr.rb
+++ b/lib/cinch/plugins/yr.rb
@@ -71,7 +71,7 @@ module Cinch
 				get_places
 
 				if loc.nil?
-					m.reply "Bruk: .yr <sted> [<kommune> og eller <fylke>]"
+					m.reply "Bruk: .yr <sted> [<kommune> og/eller <fylke>]"
 					return
 				end
 


### PR DESCRIPTION
Add a missing slash between «og» and «eller».

More info: http://www.korrekturavdelingen.no/K4Skraastrek.htm#ogeller
